### PR TITLE
Add fallback for matplotlib backend import

### DIFF
--- a/XAFSmass/XAFSmassQt.py
+++ b/XAFSmass/XAFSmassQt.py
@@ -24,7 +24,10 @@ from qtpy import QtGui, QtCore
 import qtpy.QtWidgets as QtWidgets
 
 from matplotlib.backends import qt_compat
-import matplotlib.backends.backend_qtagg as mpl_qt
+try:
+    import matplotlib.backends.backend_qtagg as mpl_qt
+except ModuleNotFoundError:
+    import matplotlib.backends.backend_qt5agg as mpl_qt
 
 Canvas = mpl_qt.FigureCanvasQTAgg
 ToolBar = mpl_qt.NavigationToolbar2QT

--- a/XAFSmass/XAFSmassQt.py
+++ b/XAFSmass/XAFSmassQt.py
@@ -25,7 +25,7 @@ import qtpy.QtWidgets as QtWidgets
 
 from matplotlib.backends import qt_compat
 if str(qtpy.API_NAME).lower() in ('pyqt6', 'pyside6'):
-    import matplotlib.backends.backend_qt6agg as mpl_qt
+    import matplotlib.backends.backend_qtagg as mpl_qt
 elif str(qtpy.API_NAME).lower() in ('pyqt5', 'pyside2'):
     import matplotlib.backends.backend_qt5agg as mpl_qt
 else:

--- a/XAFSmass/XAFSmassQt.py
+++ b/XAFSmass/XAFSmassQt.py
@@ -26,7 +26,7 @@ import qtpy.QtWidgets as QtWidgets
 from matplotlib.backends import qt_compat
 try:
     import matplotlib.backends.backend_qtagg as mpl_qt
-except ModuleNotFoundError:
+except ImportError:
     import matplotlib.backends.backend_qt5agg as mpl_qt
 
 Canvas = mpl_qt.FigureCanvasQTAgg

--- a/XAFSmass/XAFSmassQt.py
+++ b/XAFSmass/XAFSmassQt.py
@@ -24,10 +24,12 @@ from qtpy import QtGui, QtCore
 import qtpy.QtWidgets as QtWidgets
 
 from matplotlib.backends import qt_compat
-try:
-    import matplotlib.backends.backend_qtagg as mpl_qt
-except ImportError:
+if str(qtpy.API_NAME).lower() in ('pyqt6', 'pyside6'):
+    import matplotlib.backends.backend_qt6agg as mpl_qt
+elif str(qtpy.API_NAME).lower() in ('pyqt5', 'pyside2'):
     import matplotlib.backends.backend_qt5agg as mpl_qt
+else:
+    raise ImportError(f"Unsupported Qt API: {qtpy.API_NAME}. Cannot find a suitable matplotlib Qt backend.")
 
 Canvas = mpl_qt.FigureCanvasQTAgg
 ToolBar = mpl_qt.NavigationToolbar2QT


### PR DESCRIPTION
Handle missing backend by falling back to qt5agg in matplotlib < 3.5